### PR TITLE
docs: include mirror changelog info in developer docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -112,7 +112,7 @@ The process is handled by the [`mirror-changelog.yml`](.github/workflows/mirror-
 3. **Filtering:** A Node.js script located at
    [`.github/scripts/mirror-changelog.js`](.github/scripts/mirror-changelog.js)
    filters these release notes to include only changes relevant to this
-   extension. The relevance is determined by a keyword (e.g., `alloydb`), passed
+   extension. The relevance is determined by a keyword (e.g., `bigquery`), passed
    as an environment variable in the workflow file.
 4. **Changelog Injection:** The script formats the filtered entries as
    conventional commits and injects them into the PR body within a


### PR DESCRIPTION
Lint fails because base PR is not yet merged.