### PR TITLE
docs: Remove setting `BIGQUERY_USE_CLIENT_OAUTH` from setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Set the following environment variables before starting the Gemini CLI. These va
 ```bash
 export BIGQUERY_PROJECT="<your-gcp-project-id>"
 export BIGQUERY_LOCATION="<your-dataset-location>"  # Optional
-export BIGQUERY_USE_CLIENT_OAUTH="true"  # Optional
 ```
 
 Ensure [Application Default Credentials](https://cloud.google.com/docs/authentication/gcloud) are available in your environment.


### PR DESCRIPTION
`BIGQUERY_USE_CLIENT_OAUTH=true` should not be set when BigQuery tools in MCP Toolbox are running as Gemini CLI extension, and it should not be mentioned in its documentation.

This fixes https://github.com/gemini-cli-extensions/bigquery-data-analytics/issues/73