### PR TITLE
ci: update autorelease trigger label from triggered to pending in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,7 +51,7 @@ steps:
         PR_TITLE=$(echo "$$PR_DATA" | jq -r '.title')
 
         # Determine Release Version (Use double quotes and $$ for bash variables)
-        if [[ "$$PR_LABELS" == *"autorelease: triggered"* ]]; then
+        if [[ "$$PR_LABELS" == *"autorelease: pending"* ]]; then
           if [[ "$$PR_TITLE" =~ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             export RELEASE_VERSION="$${BASH_REMATCH[1]}"
           else


### PR DESCRIPTION
Because autorelease: triggered is only used momentarily while the release script is executing in the background.

Since our evaluation script is designed to run against the open Release PR before it gets merged, we should use autorelease: pending for our condition.