### PR TITLE
docs: fix open agent skills section not rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,12 @@ Enter your environment vars as described in the [configuration section](#configu
 _(Tip: Run `codex plugin list` or use the `/plugins` interactive menu to verify your installed plugins.)_
 
 </details>
+
 ## Installing using [open agent skills tool](https://github.com/vercel-labs/skills)
 
 You can install skills using the `npx skills` command.
+
+**1. Install the skills:**
 
 Run the following command in your terminal to automatically download and register the skills:
 


### PR DESCRIPTION
## Summary
- The `## Installing using [open agent skills tool]` heading sat directly below the closing `</details>` tag with no blank line, so GitHub rendered the whole section as plain text instead of a heading.
- Added the missing blank line so the heading parses correctly.
- Added the missing `**1. Install the skills:**` step label so the numbered steps read consistently (previously it jumped straight to `**2. Set env vars:**`).

## Test plan
- [ ] Verify the "Installing using open agent skills tool" section renders as a proper heading in the GitHub README preview.
