### PR TITLE
docs(marketplace): describe the plugin, not skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "data-cloud-ai-integrations@google.com"
   },
   "metadata": {
-    "description": "Agent skills for BigQuery to connect, query, and generate data insights."
+    "description": "Connect, query, and generate data insights for BigQuery datasets and data."
   },
   "plugins": [
     {

--- a/.github/workflows/presubmit-tests.yml
+++ b/.github/workflows/presubmit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Gemini CLI
         run: npm install @google/gemini-cli


### PR DESCRIPTION
Follow-up to #143. Two small fixes that landed after it merged:

- marketplace description said "Agent skills for BigQuery…"; now matches the plugin description.
- presubmit checkout pin comment said `# v7`, which zizmor flags as mismatched; the SHA is `v7.0.1`.